### PR TITLE
Implement safe pool checks in async db module

### DIFF
--- a/modules/db.py
+++ b/modules/db.py
@@ -1,0 +1,50 @@
+import logging
+import os
+from typing import Any, List, Optional
+
+import asyncpg
+
+
+log = logging.getLogger(__name__)
+
+
+class Database:
+    def __init__(self) -> None:
+        self.pool: Optional[asyncpg.Pool] = None
+
+    def _check_pool(self) -> asyncpg.Pool:
+        if not self.pool:
+            raise RuntimeError("Database not connected")
+        return self.pool
+
+    async def connect(self) -> None:
+        dsn = os.getenv("POSTGRES_DSN")
+        if not dsn:
+            raise RuntimeError("POSTGRES_DSN is not set")
+        self.pool = await asyncpg.create_pool(dsn)
+        log.info("PostgreSQL pool created")
+
+    async def close(self) -> None:
+        if self.pool:
+            await self.pool.close()
+            self.pool = None
+            log.info("PostgreSQL pool closed")
+
+    async def fetch(self, query: str, *args: Any) -> List[asyncpg.Record]:
+        pool = self._check_pool()
+        return await pool.fetch(query, *args)
+
+    async def fetchrow(self, query: str, *args: Any) -> Optional[asyncpg.Record]:
+        pool = self._check_pool()
+        return await pool.fetchrow(query, *args)
+
+    async def fetchval(self, query: str, *args: Any) -> Any:
+        pool = self._check_pool()
+        return await pool.fetchval(query, *args)
+
+    async def execute(self, query: str, *args: Any) -> str:
+        pool = self._check_pool()
+        return await pool.execute(query, *args)
+
+
+db = Database()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,47 @@
+import os
+import pytest
+import pytest_asyncio
+
+from modules.db import db
+
+DSN = "postgresql:///postgres?user=root"
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def setup_db():
+    os.environ["POSTGRES_DSN"] = DSN
+    await db.connect()
+    await db.execute("DROP TABLE IF EXISTS items")
+    await db.execute("CREATE TABLE items(id serial PRIMARY KEY, name text, value int)")
+    yield
+    await db.execute("DROP TABLE items")
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_connect_close():
+    assert db.pool is not None
+    await db.close()
+    assert db.pool is None
+    await db.connect()
+
+
+@pytest.mark.asyncio
+async def test_execute_and_fetch():
+    await db.execute("INSERT INTO items(name, value) VALUES($1, $2)", "a", 1)
+    rows = await db.fetch("SELECT * FROM items")
+    assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_fetchrow():
+    await db.execute("INSERT INTO items(name, value) VALUES($1, $2)", "b", 2)
+    row = await db.fetchrow("SELECT name FROM items WHERE value=$1", 2)
+    assert row["name"] == "b"
+
+
+@pytest.mark.asyncio
+async def test_fetchval():
+    await db.execute("INSERT INTO items(name, value) VALUES($1, $2)", "c", 3)
+    val = await db.fetchval("SELECT value FROM items WHERE name=$1", "c")
+    assert val == 3


### PR DESCRIPTION
## Summary
- add type hints and runtime pool checks

## Testing
- `ruff check .`
- `black . --check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859000aa08c832eae10fa1318e3c59c